### PR TITLE
Dep Update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,7 @@ An implementation of SSL streams for Tokio backed by OpenSSL
 
 [dependencies]
 futures = "0.3"
-openssl = "0.10.32"
-openssl-sys = "0.9"
-pin-project = "1.0"
+openssl = "0.10.34"
 tokio = "1.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ An implementation of SSL streams for Tokio backed by OpenSSL
 
 [dependencies]
 futures = "0.3"
-openssl = "0.10.34"
+openssl = "0.10.32"
 openssl-sys = "0.9"
 tokio = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ An implementation of SSL streams for Tokio backed by OpenSSL
 [dependencies]
 futures = "0.3"
 openssl = "0.10.34"
+openssl-sys = "0.9"
 tokio = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
I came across this crate and was wondering why pin-project was a dependency. Also it seems openssl-sys is also not needed as it is not referenced anywhere. I also went ahead and updated rust-openssl to the newest version, maybe it would make sense to specify this version as "0.10". I hope im not overlooking something but tests seem to pass.