### PR TITLE
use futures_util for util functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ An implementation of SSL streams for Tokio backed by OpenSSL
 """
 
 [dependencies]
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
 openssl = "0.10.32"
 openssl-sys = "0.9"
 tokio = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! blocking [`Read`] and [`Write`] traits.
 #![warn(missing_docs)]
 
-use futures::future;
+use futures_util::future;
 use openssl::error::ErrorStack;
 use openssl::ssl::{self, ErrorCode, ShutdownResult, Ssl, SslRef};
 use std::fmt;

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,5 @@
 use crate::SslStream;
-use futures::future;
+use futures_util::future;
 use openssl::ssl::{Ssl, SslAcceptor, SslConnector, SslFiletype, SslMethod};
 use std::net::ToSocketAddrs;
 use std::pin::Pin;


### PR DESCRIPTION
Use `futures-util` would reduce dep tree and enable building for a no proc macro project.